### PR TITLE
fix: modify the linux ids

### DIFF
--- a/pkg/minimk3/ids_linux.go
+++ b/pkg/minimk3/ids_linux.go
@@ -3,7 +3,7 @@ package minimk3
 import "regexp"
 
 var (
-	rxDAW     = regexp.MustCompile(`Launchpad Mini MK3:Launchpad Mini MK3 MIDI 2`)
-	rxMidiIn  = regexp.MustCompile(`Launchpad Mini MK3:Launchpad Mini MK3 MIDI 1`)
-	rxMidiOut = regexp.MustCompile(`Launchpad Mini MK3:Launchpad Mini MK3 MIDI 1`)
+	rxDAW     = regexp.MustCompile(`Launchpad Mini MK3:Launchpad Mini MK3 (MIDI 2|LPMiniMK3 DA)`)
+	rxMidiIn  = regexp.MustCompile(`Launchpad Mini MK3:Launchpad Mini MK3 (MIDI 1|LPMiniMK3 MI)`)
+	rxMidiOut = regexp.MustCompile(`Launchpad Mini MK3:Launchpad Mini MK3 (MIDI 1|LPMiniMK3 MI)`)
 )


### PR DESCRIPTION
Hi,
on my system (CachyOS), the Linux IDs did not match the Launchpad name.
I get these Names:
- `Launchpad Mini MK3:Launchpad Mini MK3 LPMiniMK3 DA`
- `Launchpad Mini MK3:Launchpad Mini MK3 LPMiniMK3 MI`

I updated the regexp to match both the existing MIDI naming scheme and the LPMiniMK3 DA/MI variants, so device detection should work on both setups.